### PR TITLE
DL-178: Skip non-ControllerActionDescriptor descriptors

### DIFF
--- a/src/VirtoCommerce.ExportModule.Data/Security/AnyPolicyAuthorizationFilter.cs
+++ b/src/VirtoCommerce.ExportModule.Data/Security/AnyPolicyAuthorizationFilter.cs
@@ -27,9 +27,9 @@ namespace VirtoCommerce.ExportModule.Data.Security
             Authorize(context).GetAwaiter().GetResult();
         }
 
-        public async Task OnAuthorizationAsync(AuthorizationFilterContext context)
+        public Task OnAuthorizationAsync(AuthorizationFilterContext context)
         {
-            await Authorize(context);
+            return Authorize(context);
         }
 
         private async Task Authorize(AuthorizationFilterContext context)
@@ -51,9 +51,9 @@ namespace VirtoCommerce.ExportModule.Data.Security
         /// <returns></returns>
         private string[] GetActionPolicies(AuthorizationFilterContext context)
         {
-            var result = new string[] { };
-            var controllerActionDescriptor = (ControllerActionDescriptor)context.ActionDescriptor;
-            var authorizeAnyAttribute = controllerActionDescriptor.MethodInfo.GetCustomAttributes(typeof(AuthorizeAnyAttribute), true).Cast<AuthorizeAnyAttribute>().FirstOrDefault();
+            var result = System.Array.Empty<string>();
+            var controllerActionDescriptor = context.ActionDescriptor as ControllerActionDescriptor; // For controller actions only. Everything else (like, for example, CompiledPageActionDescriptor) should be skipped.
+            var authorizeAnyAttribute = controllerActionDescriptor?.MethodInfo.GetCustomAttributes(typeof(AuthorizeAnyAttribute), true).Cast<AuthorizeAnyAttribute>().FirstOrDefault();
             if (authorizeAnyAttribute != null)
             {
                 result = authorizeAnyAttribute.Policies;


### PR DESCRIPTION
## Description
Skips non-ControllerActionDescriptor descriptors in applying action policies, otherwise, the Platform fails in hosting self-controlled Razor-pages.
In DL-178 spike was discovered the platform can't host razor pages. When this feature [was enabled](https://github.com/VirtoCommerce/vc-platform/pull/2458), the platform wasn't serve any controller when the export module is installed. It happened because not every controller action in the system should be ControllerActionDescriptor. The changes presented in PR.
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/DL-178
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Export_3.201.0-pr-64.zip
