### PR TITLE
Fix filtered map for bool

### DIFF
--- a/src/VirtoCommerce.ExportModule.CsvProvider/MetadataFilteredMap.cs
+++ b/src/VirtoCommerce.ExportModule.CsvProvider/MetadataFilteredMap.cs
@@ -93,7 +93,7 @@ namespace VirtoCommerce.ExportModule.CsvProvider
 
             memberMap.Data.TypeConverterOptions.CultureInfo = CultureInfo.InvariantCulture;
             memberMap.Data.TypeConverterOptions.NumberStyles = NumberStyles.Any;
-            memberMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(new List<string>() { "yes", "true" });
+            memberMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(new List<string>() { "true", "yes" });
             memberMap.Data.TypeConverterOptions.BooleanFalseValues.AddRange(new List<string>() { "false", "no" });
             memberMap.Data.Names.Add(columnName);
             memberMap.Data.NameIndex = memberMap.Data.Names.Count - 1;

--- a/src/VirtoCommerce.ExportModule.CsvProvider/MetadataFilteredMap.cs
+++ b/src/VirtoCommerce.ExportModule.CsvProvider/MetadataFilteredMap.cs
@@ -93,8 +93,8 @@ namespace VirtoCommerce.ExportModule.CsvProvider
 
             memberMap.Data.TypeConverterOptions.CultureInfo = CultureInfo.InvariantCulture;
             memberMap.Data.TypeConverterOptions.NumberStyles = NumberStyles.Any;
-            memberMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(new List<string>() { "true", "yes" });
-            memberMap.Data.TypeConverterOptions.BooleanFalseValues.AddRange(new List<string>() { "false", "no" });
+            memberMap.Data.TypeConverterOptions.BooleanTrueValues.AddRange(new List<string>() { "True", "Yes" });
+            memberMap.Data.TypeConverterOptions.BooleanFalseValues.AddRange(new List<string>() { "False", "No" });
             memberMap.Data.Names.Add(columnName);
             memberMap.Data.NameIndex = memberMap.Data.Names.Count - 1;
             memberMap.Data.Index = ++columnIndex;


### PR DESCRIPTION
## Description
The correction is necessary so that when importing files, values with the "bool" type are correctly replaced. To get the correct match and eliminate errors when using parsing in bool values.

When exporting the bool value "true" in the csv file, the values "yes" were obtained, which made it impossible to convert the value to the "bool" type and caused an exception.
## References
### QA-test:
### Jira-link:
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Export_3.801.0-pr-85-ecca.zip
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Export_3.801.0-pr-85-95f4.zip
