### PR TITLE
fix: Fix searching by object ids when count is more than 50

### DIFF
--- a/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
+++ b/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
@@ -58,7 +58,7 @@ namespace VirtoCommerce.ExportModule.Data.Services
             {
                 searchCriteria.ObjectIds = searchCriteria.ObjectIds.Skip(searchCriteria.Skip).Take(searchCriteria.Take).ToArray();
                 searchCriteria.Skip = 0;
-                searchCriteria.Take = searchCriteria.ObjectIds.Count;
+                searchCriteria.Take = searchCriteria.ObjectIds.Count < searchCriteria.Take ? searchCriteria.ObjectIds.Count : searchCriteria.Take;
             }
 
             if (hasObjectIds && searchCriteria.ObjectIds.IsNullOrEmpty())

--- a/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
+++ b/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
@@ -57,6 +57,8 @@ namespace VirtoCommerce.ExportModule.Data.Services
             if (hasObjectIds)
             {
                 searchCriteria.ObjectIds = searchCriteria.ObjectIds.Skip(searchCriteria.Skip).Take(searchCriteria.Take).ToArray();
+                searchCriteria.Skip = 0;
+                searchCriteria.Take = searchCriteria.ObjectIds.Count < searchCriteria.Take ? searchCriteria.ObjectIds.Count : searchCriteria.Take;
             }
 
             if (hasObjectIds && searchCriteria.ObjectIds.IsNullOrEmpty())
@@ -66,14 +68,7 @@ namespace VirtoCommerce.ExportModule.Data.Services
 
             if (hasData)
             {
-                var fetchDataSearchCriteria = searchCriteria.CloneTyped();
-                if (hasObjectIds)
-                {
-                    fetchDataSearchCriteria.Skip = 0;
-                    fetchDataSearchCriteria.Take = searchCriteria.ObjectIds.Count < searchCriteria.Take ? searchCriteria.ObjectIds.Count : searchCriteria.Take;
-                }
-
-                var data = FetchData(fetchDataSearchCriteria);
+                var data = FetchData(searchCriteria);
 
                 CurrentPageNumber++;
                 Items = data.Results;

--- a/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
+++ b/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
@@ -57,8 +57,6 @@ namespace VirtoCommerce.ExportModule.Data.Services
             if (hasObjectIds)
             {
                 searchCriteria.ObjectIds = searchCriteria.ObjectIds.Skip(searchCriteria.Skip).Take(searchCriteria.Take).ToArray();
-                searchCriteria.Skip = 0;
-                searchCriteria.Take = searchCriteria.ObjectIds.Count < searchCriteria.Take ? searchCriteria.ObjectIds.Count : searchCriteria.Take;
             }
 
             if (hasObjectIds && searchCriteria.ObjectIds.IsNullOrEmpty())
@@ -68,7 +66,14 @@ namespace VirtoCommerce.ExportModule.Data.Services
 
             if (hasData)
             {
-                var data = FetchData(searchCriteria);
+                var fetchDataSearchCriteria = searchCriteria.CloneTyped();
+                if (hasObjectIds)
+                {
+                    fetchDataSearchCriteria.Skip = 0;
+                    fetchDataSearchCriteria.Take = searchCriteria.ObjectIds.Count < searchCriteria.Take ? searchCriteria.ObjectIds.Count : searchCriteria.Take;
+                }
+
+                var data = FetchData(fetchDataSearchCriteria);
 
                 CurrentPageNumber++;
                 Items = data.Results;

--- a/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
+++ b/src/VirtoCommerce.ExportModule.Data/Services/ExportPagedDataSource.cs
@@ -57,6 +57,8 @@ namespace VirtoCommerce.ExportModule.Data.Services
             if (hasObjectIds)
             {
                 searchCriteria.ObjectIds = searchCriteria.ObjectIds.Skip(searchCriteria.Skip).Take(searchCriteria.Take).ToArray();
+                searchCriteria.Skip = 0;
+                searchCriteria.Take = searchCriteria.ObjectIds.Count;
             }
 
             if (hasObjectIds && searchCriteria.ObjectIds.IsNullOrEmpty())


### PR DESCRIPTION
## Description
When providing more then 50 objects to export, datasource was exporting only 50, and next pages where not searched, because of skip params.
## References
### QA-test:
### Jira-link: https://dev.azure.com/omnia-opus/OPUS/_workitems/edit/4900/
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Export_3.805.0-pr-91-07a3.zip