### PR TITLE
VCST-5163: Stable 15 — Export (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.ExportModule.Core/Services/IDataExporter.cs
+++ b/src/VirtoCommerce.ExportModule.Core/Services/IDataExporter.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.IO;
 using VirtoCommerce.ExportModule.Core.Model;
 using VirtoCommerce.Platform.Core.Common;
@@ -10,6 +11,6 @@ namespace VirtoCommerce.ExportModule.Core.Services
     /// </summary>
     public interface IDataExporter
     {
-        void Export(Stream stream, ExportDataRequest request, Action<ExportProgressInfo> progressCallback, ICancellationToken token);
+        void Export(Stream stream, ExportDataRequest request, Action<ExportProgressInfo> progressCallback, CancellationToken token);
     }
 }

--- a/src/VirtoCommerce.ExportModule.Core/VirtoCommerce.ExportModule.Core.csproj
+++ b/src/VirtoCommerce.ExportModule.Core/VirtoCommerce.ExportModule.Core.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ExportModule.Data/Services/DataExporter.cs
+++ b/src/VirtoCommerce.ExportModule.Data/Services/DataExporter.cs
@@ -1,4 +1,4 @@
-using System;
+using System;
 using System.Threading;
 using System.Collections.Generic;
 using System.IO;
@@ -66,27 +66,7 @@ namespace VirtoCommerce.ExportModule.Data.Services
                     token.ThrowIfCancellationRequested();
                     foreach (var obj in pagedDataSource.Items)
                     {
-                        try
-                        {
-                            var preparedObject = obj.CloneTyped();
-
-                            if (preparedObject is IEnumerable<IExportable> enumerable)
-                            {
-                                foreach (var exportable in enumerable)
-                                {
-                                    WriteRecord(exportProvider, writer, request, exportable, needTabularData);
-                                }
-                            }
-                            else
-                            {
-                                WriteRecord(exportProvider, writer, request, preparedObject, needTabularData);
-                            }
-                        }
-                        catch (Exception e)
-                        {
-                            exportProgress.Errors.Add(e.Message);
-                            progressCallback(exportProgress);
-                        }
+                        ExportObject(exportProvider, writer, request, obj, needTabularData, exportProgress, progressCallback);
                         exportedCount++;
                     }
 
@@ -115,6 +95,31 @@ namespace VirtoCommerce.ExportModule.Data.Services
             }
         }
 
+
+        private static void ExportObject(IExportProvider exportProvider, TextWriter writer, ExportDataRequest request, IExportable obj, bool needTabularData, ExportProgressInfo exportProgress, Action<ExportProgressInfo> progressCallback)
+        {
+            try
+            {
+                var preparedObject = obj.CloneTyped();
+
+                if (preparedObject is IEnumerable<IExportable> enumerable)
+                {
+                    foreach (var exportable in enumerable)
+                    {
+                        WriteRecord(exportProvider, writer, request, exportable, needTabularData);
+                    }
+                }
+                else
+                {
+                    WriteRecord(exportProvider, writer, request, preparedObject, needTabularData);
+                }
+            }
+            catch (Exception e)
+            {
+                exportProgress.Errors.Add(e.Message);
+                progressCallback(exportProgress);
+            }
+        }
 
         private static void WriteRecord(IExportProvider exportProvider, TextWriter writer, ExportDataRequest request, IExportable exportable, bool needTabularData)
         {

--- a/src/VirtoCommerce.ExportModule.Data/Services/DataExporter.cs
+++ b/src/VirtoCommerce.ExportModule.Data/Services/DataExporter.cs
@@ -1,4 +1,5 @@
-using System;
+using System;
+using System.Threading;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -20,7 +21,7 @@ namespace VirtoCommerce.ExportModule.Data.Services
             _exportProviderFactory = exportProviderFactory;
         }
 
-        public void Export(Stream stream, ExportDataRequest request, Action<ExportProgressInfo> progressCallback, ICancellationToken token)
+        public void Export(Stream stream, ExportDataRequest request, Action<ExportProgressInfo> progressCallback, CancellationToken token)
         {
             if (request == null)
             {

--- a/src/VirtoCommerce.ExportModule.Data/VirtoCommerce.ExportModule.Data.csproj
+++ b/src/VirtoCommerce.ExportModule.Data/VirtoCommerce.ExportModule.Data.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
   <ItemGroup>
     
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
     <ProjectReference Include="..\VirtoCommerce.ExportModule.Core\VirtoCommerce.ExportModule.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.ExportModule.Web/BackgroundJobs/ExportJob.cs
+++ b/src/VirtoCommerce.ExportModule.Web/BackgroundJobs/ExportJob.cs
@@ -48,7 +48,7 @@ namespace VirtoCommerce.ExportModule.Web.BackgroundJobs
 
                 await using (var stream = await _exportFileStorage.OpenWriteAsync(fileName))
                 {
-                    _dataExporter.Export(stream, request, ProgressCallback, new JobCancellationTokenWrapper(cancellationToken));
+                    _dataExporter.Export(stream, request, ProgressCallback, cancellationToken.ShutdownToken);
                 }
 
                 notification.DownloadUrl = $"/api/export/download/{fileName}";

--- a/src/VirtoCommerce.ExportModule.Web/Controllers/Api/ExportController.cs
+++ b/src/VirtoCommerce.ExportModule.Web/Controllers/Api/ExportController.cs
@@ -158,7 +158,11 @@ namespace VirtoCommerce.ExportModule.Web.Controllers
         /// <returns></returns>
         [HttpGet]
         [Route("download/{fileName}")]
+        // VC0015: PlatformExport permission was moved to the BackupRestore module but the platform keeps
+        // the constant for backward compatibility; keep using it here to avoid an Export->BackupRestore dependency.
+#pragma warning disable VC0015
         [AuthorizeAny(PlatformConstants.Security.Permissions.PlatformExport, ModuleConstants.Security.Permissions.Download)]
+#pragma warning restore VC0015
         public async Task<ActionResult> DownloadExportFile([FromRoute] string fileName)
         {
             var contentType = MimeTypeResolver.ResolveContentType(fileName);

--- a/src/VirtoCommerce.ExportModule.Web/VirtoCommerce.ExportModule.Web.csproj
+++ b/src/VirtoCommerce.ExportModule.Web/VirtoCommerce.ExportModule.Web.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1002.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="VirtoCommerce.Platform.Hangfire" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.ExportModule.Core\VirtoCommerce.ExportModule.Core.csproj" />

--- a/src/VirtoCommerce.ExportModule.Web/module.manifest
+++ b/src/VirtoCommerce.ExportModule.Web/module.manifest
@@ -4,9 +4,9 @@
   <version>3.1002.0</version>
   <version-tag />
 
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
   </dependencies>
 
   <title>Generic Export</title>


### PR DESCRIPTION
Part of **Stable 15** (Wave 2). Platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave-1 deps (nuget.org). Branch actualized with latest dev. `vc-build Compress` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public `IDataExporter` signature change may break other modules, and the platform upgrade affects Hangfire export jobs and download authorization semantics.
> 
> **Overview**
> Bumps the Export module for **Stable 15**: `module.manifest` and package references target **platform 3.1039.0**, **VirtoCommerce.Assets 3.1005.0**, and **Microsoft.AspNetCore.Mvc.NewtonsoftJson 10.0.9**.
> 
> **Export cancellation** now uses `System.Threading.CancellationToken` on `IDataExporter.Export` instead of the platform `ICancellationToken`. `ExportJob` passes Hangfire’s `cancellationToken.ShutdownToken` directly, dropping `JobCancellationTokenWrapper`.
> 
> `DataExporter` pulls per-item clone/write/error handling into a private `ExportObject` method; behavior is unchanged.
> 
> The export **download** action keeps authorizing with the legacy `PlatformConstants.Security.Permissions.PlatformExport` constant under `#pragma warning disable VC0015`, with a comment that the permission moved to BackupRestore but the constant remains for backward compatibility without a module dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e60cb10248f074878f0ae94785050812dda164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Export_3.1003.0-pr-102-53e6.zip